### PR TITLE
`GrouperView.join()` no longer exists, use `sharey()` instead

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,10 +20,10 @@ jobs:
         requirements: [minimal_requirements.txt, requirements.txt]
         include:
           - os: macos-latest
-            python-version: '3.10'
+            python-version: '3.13'
             requirements: requirements.txt
           - os: windows-latest
-            python-version: '3.10'
+            python-version: '3.13'
             requirements: requirements.txt
 
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         requirements: [minimal_requirements.txt, requirements.txt]
         include:
           - os: macos-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10']
         requirements: [minimal_requirements.txt, requirements.txt]
         include:
           - os: macos-latest

--- a/README.rst
+++ b/README.rst
@@ -251,7 +251,9 @@ Plot user-generated samples
     plot_dkl(f, x, samples, prior_samples, ax_dkl,
              cache=cache, prior_cache=prior_cache)
 
-    ax_lines.get_shared_x_axes().join(ax_lines, ax_fgivenx, ax_samples)
+
+    ax_lines.sharey(ax_fgivenx)
+    ax_fgivenx.sharey(ax_samples)
 
     fig.tight_layout()
     fig.savefig('plot.png')

--- a/fgivenx/mass.py
+++ b/fgivenx/mass.py
@@ -98,11 +98,11 @@ def PMF(samples, y):
                 starts = numpy.where(numpy.logical_and(bools[:-1], ~bools[1:]))
 
                 # Compute locations
-                starts = [scipy.optimize.brentq(lambda u: kernel(u)-p,
+                starts = [scipy.optimize.brentq(lambda u: (kernel(u)-p)[0],
                                                 y_[i], y_[i+1])
                           for i in starts[0]]
                 starts = [-numpy.inf] + starts
-                stops = [scipy.optimize.brentq(lambda u: kernel(u)-p,
+                stops = [scipy.optimize.brentq(lambda u: (kernel(u)-p)[0],
                                                y_[i], y_[i+1])
                          for i in stops[0]]
                 stops = stops + [numpy.inf]

--- a/fgivenx/mass.py
+++ b/fgivenx/mass.py
@@ -14,7 +14,7 @@ def PMF(samples, y):
 
         From :math:`P(y)` we define:
 
-        :math:`\mathrm{pmf}(p) = \int_{P(y)<p} P(y) dy`
+        :math:`\\mathrm{pmf}(p) = \\int_{P(y)<p} P(y) dy`
 
         This is the cumulative distribution function expressed as a
         function of the probability

--- a/fgivenx/mass.py
+++ b/fgivenx/mass.py
@@ -98,12 +98,12 @@ def PMF(samples, y):
                 starts = numpy.where(numpy.logical_and(bools[:-1], ~bools[1:]))
 
                 # Compute locations
-                starts = [scipy.optimize.brentq(lambda u: (kernel(u)-p)[0],
-                                                y_[i], y_[i+1])
+                starts = [scipy.optimize.brentq(
+                    lambda u: (kernel(u)-p).squeeze(), y_[i], y_[i+1])
                           for i in starts[0]]
                 starts = [-numpy.inf] + starts
-                stops = [scipy.optimize.brentq(lambda u: (kernel(u)-p)[0],
-                                               y_[i], y_[i+1])
+                stops = [scipy.optimize.brentq(
+                    lambda u: (kernel(u)-p).squeeze(), y_[i], y_[i+1])
                          for i in stops[0]]
                 stops = stops + [numpy.inf]
 

--- a/fgivenx/plot.py
+++ b/fgivenx/plot.py
@@ -102,8 +102,7 @@ def plot(x, y, z, ax=None, **kwargs):
             c.set_rasterized(True)
 
     # Remove those annoying white lines
-    for c in cbar.collections:
-        c.set_edgecolor("face")
+    cbar.set_edgecolor("face")
 
     # Plot some sigma-based contour lines
     if lines:

--- a/fgivenx/plot.py
+++ b/fgivenx/plot.py
@@ -98,8 +98,7 @@ def plot(x, y, z, ax=None, **kwargs):
 
     # Rasterize contours (the rest of the figure stays in vector format)
     if rasterize_contours:
-        for c in cbar.collections:
-            c.set_rasterized(True)
+        cbar.set_rasterized(True)
 
     # Remove those annoying white lines
     cbar.set_edgecolor("face")

--- a/fgivenx/test/test_drivers.py
+++ b/fgivenx/test/test_drivers.py
@@ -134,5 +134,7 @@ def test_plotting():
         plot_dkl(f, x, samples, prior_samples, ax_dkl,
                  cache=cache, prior_cache=prior_cache)
 
-        ax_lines.get_shared_x_axes().join(ax_lines, ax_fgivenx, ax_samples)
+        # ax_lines.get_shared_x_axes().join(ax_lines, ax_fgivenx, ax_samples)
+        ax_lines.sharey(ax_fgivenx)
+        ax_fgivenx.sharey(ax_samples)
         fig.set_size_inches(6, 6)

--- a/fgivenx/test/test_drivers.py
+++ b/fgivenx/test/test_drivers.py
@@ -134,7 +134,6 @@ def test_plotting():
         plot_dkl(f, x, samples, prior_samples, ax_dkl,
                  cache=cache, prior_cache=prior_cache)
 
-        # ax_lines.get_shared_x_axes().join(ax_lines, ax_fgivenx, ax_samples)
         ax_lines.sharey(ax_fgivenx)
         ax_fgivenx.sharey(ax_samples)
         fig.set_size_inches(6, 6)

--- a/fgivenx/test/test_mass.py
+++ b/fgivenx/test/test_mass.py
@@ -42,7 +42,7 @@ def test_PMF():
     assert_allclose(m, m_, atol=3*N**-0.5)
 
     # Compute PMF via quadrature
-    m_ = [scipy.integrate.quad(lambda x: kernel(x)*(kernel(x) <= kernel(y_i)),
+    m_ = [scipy.integrate.quad(lambda x: (kernel(x)*(kernel(x) <= kernel(y_i)))[0],
                                -numpy.inf, numpy.inf, limit=500)[0]
           for y_i in y]
     assert_allclose(m, m_, atol=1e-4)


### PR DESCRIPTION
# Description

`GrouperView` no longer has a `.join()` method, so use `sharey()` instead. https://stackoverflow.com/questions/77418896/attributeerror-grouperview-object-has-no-attribute-join

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
