### PR TITLE
share x axes in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -252,6 +252,8 @@ Plot user-generated samples
              cache=cache, prior_cache=prior_cache)
 
 
+    ax_lines.sharex(ax_fgivenx)
+    ax_dkl.sharex(ax_fgivenx)
     ax_lines.sharey(ax_fgivenx)
     ax_fgivenx.sharey(ax_samples)
 


### PR DESCRIPTION
# Description

While I don't think the issue is as drastic as it appears in #21, we should also share x axes to produce plot.pdf as shown in the readme (so that the x limits are (-2, 2))

Fixes #21

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] copied the new readme into a python file and ran on my laptop. Result identical to plot.pdf to within sampling noise.
<img width="1189" alt="Screenshot 2025-02-09 at 15 44 51" src="https://github.com/user-attachments/assets/9eb60c29-0928-469f-9916-0fcab5507a5c" />


**Test Configuration**:
* Firmware version: macOS Sequoia 15.3
* Hardware: M1 pro macbook pro
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
